### PR TITLE
add Chavenet's criterion for wmean calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 Manifest.toml
 /dev
+.vscode

--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
 Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
+SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 VectorizedStatistics = "3b853605-1c98-4422-8364-4bd93ee0529e"
 
 [weakdeps]

--- a/src/regression.jl
+++ b/src/regression.jl
@@ -102,6 +102,7 @@ function wmean(x::Collection{Measurement{T}}; corrected::Bool=true, chauvenet::B
     if chauvenet
         not_outliers = chauvenet_func(μ, σ)
         x = x[not_outliers]
+        μ, σ = val.(x), err.(x)
     end
 
     sum_of_values = sum_of_weights = χ² = zero(float(T))
@@ -172,7 +173,13 @@ julia> mswd(x, ones(10))
 1.3901517474017941
 ```
 """
-function mswd(μ::Collection{T}, σ::Collection) where {T}
+function mswd(μ::Collection{T}, σ::Collection; chauvenet=false) where {T}
+    if chauvenet
+        not_outliers = chauvenet_func(μ, σ)
+        μ = μ[not_outliers]
+        σ = σ[not_outliers]
+    end
+
     sum_of_values = sum_of_weights = χ² = zero(float(T))
 
     @inbounds for i in eachindex(μ,σ)
@@ -189,7 +196,13 @@ function mswd(μ::Collection{T}, σ::Collection) where {T}
     return χ² / (length(μ)-1)
 end
 
-function mswd(x::Collection{Measurement{T}}) where {T}
+function mswd(x::Collection{Measurement{T}}; chauvenet=false) where {T}
+
+    if chauvenet
+        not_outliers = chauvenet_func(val.(x), err.(x))
+        x = x[not_outliers]
+    end
+
     sum_of_values = sum_of_weights = χ² = zero(float(T))
 
     @inbounds for i in eachindex(x)

--- a/src/regression.jl
+++ b/src/regression.jl
@@ -97,9 +97,9 @@ function wmean(μ::Collection{T}, σ::Collection; corrected::Bool=true, chauvene
 end
 
 function wmean(x::Collection{Measurement{T}}; corrected::Bool=true, chauvenet::Bool=false) where {T}
-    μ, σ = val.(x), err.(x)
 
     if chauvenet
+        μ, σ = val.(x), err.(x)
         not_outliers = chauvenet_func(μ, σ)
         x = x[not_outliers]
         μ, σ = val.(x), err.(x)

--- a/src/regression.jl
+++ b/src/regression.jl
@@ -102,7 +102,6 @@ function wmean(x::Collection{Measurement{T}}; corrected::Bool=true, chauvenet::B
         μ, σ = val.(x), err.(x)
         not_outliers = chauvenet_func(μ, σ)
         x = x[not_outliers]
-        μ, σ = val.(x), err.(x)
     end
 
     sum_of_values = sum_of_weights = χ² = zero(float(T))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -214,12 +214,15 @@ module BaseTests
         @test std(d) ≈ σ atol = 2
 
         # test chauvenet criterion
-        μ = [1.2, 1.5, 1.3, 2.4, 2.0, 2.1, 1.9, 2.2, 8.0, 2.3]
-        σ = [1,1,1,1,1,1,1,1,1,1.]
+        x = [1.2, 1.5, 1.3, 2.4, 2.0, 2.1, 1.9, 2.2, 8.0, 2.3]
+        xσ = [1,1,1,1,1,1,1,1,1,1.]
         expected = [true, true, true, true, true, true, true, true, false, true]
-        @test Isoplot.chauvenet_func(μ, σ) == expected
-        μ,σ,MSWD = wmean(μ, σ;chauvenet=true)
+        @test Isoplot.chauvenet_func(x, xσ) == expected
+        μ,σ,MSWD = wmean(x, xσ;chauvenet=true)
         @test μ ≈ 1.877777777777778
+        @test MSWD ≈ 0.19444444444444445
+        μ, MSWD = wmean((x .± xσ);chauvenet=true)
+        @test Isoplot.val(μ) ≈ 1.877777777777778
         @test MSWD ≈ 0.19444444444444445
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -178,7 +178,6 @@ module BaseTests
         @test mean(d) ≈ μ atol = 0.2
         @test std(d) ≈ σ atol = 2
 
-
         a,b = 2randn(N), 3randn(N).+1
         d = distwmean(a,b; corrected=false)
         μ,σ,_ = wmean([0,1], [2,3]; corrected=false)
@@ -213,6 +212,15 @@ module BaseTests
         μ,σ,_ = wmean([0,50,100], [2,1,3]; corrected=true)
         @test mean(d) ≈ μ atol = 0.2
         @test std(d) ≈ σ atol = 2
+
+        # test chauvenet criterion
+        μ = [1.2, 1.5, 1.3, 2.4, 2.0, 2.1, 1.9, 2.2, 8.0, 2.3]
+        σ = [1,1,1,1,1,1,1,1,1,1.]
+        expected = [true, true, true, true, true, true, true, true, false, true]
+        @test Isoplot.chauvenet_func(μ, σ) == expected
+        μ,σ,MSWD = wmean(μ, σ;chauvenet=true)
+        @test μ ≈ 1.877777777777778
+        @test MSWD ≈ 0.19444444444444445
     end
 
     data = [1.1009 0.00093576 0.123906 0.00002849838 0.319
@@ -443,14 +451,14 @@ module MakieTest
         @test size(img) == (900, 1200)
         @test sum(img)/length(img) ≈ RGB{Float64}(0.8524913580246877,0.8524913580246877,0.9885884168482209) rtol = 0.02
         rm("concordia.png")
-    
+
         # Plot many concordia ellipses and concordia curve
         f2 = Figure()
         ax2 = Axis(f2[1,1])
         plot!.(analyses, color=(:blue, 0.3))
         ages = age.(analyses)
         concordiacurve!(minimum(ages)[1].val-5,maximum(ages)[1].val+5)
-        
+
         xmin, xmax, ymin, ymax = datalimits(analyses)
         limits!(ax2,xmin,xmax,ymin,ymax)
         save("concordia.png",f2)
@@ -458,7 +466,7 @@ module MakieTest
         @test size(img) == (900, 1200)
         @test sum(img)/length(img) ≈ RGB{Float64}(0.9523360547065816,0.9523360547065816,0.9661779080315414) rtol = 0.01
         rm("concordia.png")
-    
+
         # Plot single concordia line
         f3 = Figure()
         ax3 = Axis(f3[1,1])
@@ -469,6 +477,7 @@ module MakieTest
         @test size(img) == (900, 1200)
         @test sum(img)/length(img) ≈ RGB{Float64}(0.9845678970995279,0.9845678970995279,0.9845678970995279) rtol = 0.01
         rm("concordia.png")
-       
+
     end
 end
+


### PR DESCRIPTION
Hi, I needed this so I've added Chavenet's criterion, which is used for outlier detection when computing the weighted mean.

In practice, I've added a new boolean to wmean() and MSWD() to allow the use of the Chavenet's criterion. Also add a dependency to SpecialFunctions.jl for erfc() but it is a small package so this looks reasonable to me. Tests have been added and are passing too.

That's add a few allocations to the computation only when `chavenet=true` and I don't think we can get ride of these. Tell me what you think.

Cheers